### PR TITLE
Update notifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/mercure-bundle": "^0.3.2",
         "symfony/messenger": "*",
         "symfony/monolog-bundle": "^3.1",
-        "symfony/notifier": ">=5.4",
+        "symfony/notifier": "*",
         "symfony/process": "*",
         "symfony/property-access": "*",
         "symfony/property-info": "*",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/mercure-bundle": "^0.3.2",
         "symfony/messenger": "*",
         "symfony/monolog-bundle": "^3.1",
-        "symfony/notifier": "5.2.*",
+        "symfony/notifier": "*",
         "symfony/process": "*",
         "symfony/property-access": "*",
         "symfony/property-info": "*",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/mercure-bundle": "^0.3.2",
         "symfony/messenger": "*",
         "symfony/monolog-bundle": "^3.1",
-        "symfony/notifier": "*",
+        "symfony/notifier": ">=5.4",
         "symfony/process": "*",
         "symfony/property-access": "*",
         "symfony/property-info": "*",


### PR DESCRIPTION
This [commit](https://github.com/symfony/framework-bundle/commit/df83241a4c1ed0782494a38d3d46f8ead9832f51) adds `PushMessage` to the config in `notifier.php` in the `symfony/framework-bundle`.

So either updating the notifier component or adding a `conflicts` entry would be a path to go I think?