### PR TITLE
Fixed broken build on Symfony 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "symfony/property-info": "5.4.*",
         "symfony/proxy-manager-bridge": "5.4.*",
         "symfony/rate-limiter": "5.4.*",
+        "symfony/routing": "5.4.*",
         "symfony/security-bundle": "5.4.*",
         "symfony/serializer": "5.4.*",
         "symfony/translation": "5.4.*",

--- a/config/packages/lock.yaml
+++ b/config/packages/lock.yaml
@@ -1,0 +1,2 @@
+framework:
+    lock: '%env(LOCK_DSN)%'

--- a/config/packages/notifier.yaml
+++ b/config/packages/notifier.yaml
@@ -1,0 +1,16 @@
+framework:
+    notifier:
+        #chatter_transports:
+        #    slack: '%env(SLACK_DSN)%'
+        #    telegram: '%env(TELEGRAM_DSN)%'
+        #texter_transports:
+        #    twilio: '%env(TWILIO_DSN)%'
+        #    nexmo: '%env(NEXMO_DSN)%'
+        channel_policy:
+            # use chat/slack, chat/telegram, sms/twilio or sms/nexmo
+            urgent: ['email']
+            high: ['email']
+            medium: ['email']
+            low: ['email']
+        admin_recipients:
+            - { email: admin@example.com }

--- a/symfony.lock
+++ b/symfony.lock
@@ -13,11 +13,8 @@
             "src/Entity/.gitignore"
         ]
     },
-    "composer/package-versions-deprecated": {
-        "version": "1.11.99.1"
-    },
     "doctrine/annotations": {
-        "version": "1.0",
+        "version": "1.13",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
@@ -29,27 +26,27 @@
         ]
     },
     "doctrine/cache": {
-        "version": "1.10.2"
+        "version": "2.1.1"
     },
     "doctrine/collections": {
-        "version": "1.6.7"
+        "version": "1.6.8"
     },
     "doctrine/common": {
-        "version": "3.1.2"
+        "version": "3.2.0"
     },
     "doctrine/dbal": {
-        "version": "2.13.0"
+        "version": "3.2.0"
     },
     "doctrine/deprecations": {
         "version": "v0.5.3"
     },
     "doctrine/doctrine-bundle": {
-        "version": "2.3",
+        "version": "2.5",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "2.3",
-            "ref": "6e0f582596a8f1c865aaa0d3cceb9bf0daf609b4"
+            "version": "2.4",
+            "ref": "032f52ed50a27762b78ca6a2aaf432958c473553"
         },
         "files": [
             "config/packages/doctrine.yaml",
@@ -63,7 +60,7 @@
         "version": "1.1.1"
     },
     "doctrine/inflector": {
-        "version": "2.0.3"
+        "version": "2.0.4"
     },
     "doctrine/instantiator": {
         "version": "1.4.0"
@@ -72,67 +69,64 @@
         "version": "1.2.1"
     },
     "doctrine/orm": {
-        "version": "2.8.4"
+        "version": "2.10.3"
     },
     "doctrine/persistence": {
-        "version": "2.1.0"
+        "version": "2.2.3"
     },
     "doctrine/sql-formatter": {
-        "version": "1.1.1"
+        "version": "1.1.2"
     },
     "egulias/email-validator": {
-        "version": "3.1.1"
+        "version": "3.1.2"
     },
     "fig/link-util": {
         "version": "1.2.0"
     },
     "friendsofphp/proxy-manager-lts": {
-        "version": "v1.0.3"
+        "version": "v1.0.5"
     },
     "laminas/laminas-code": {
-        "version": "4.2.0"
-    },
-    "laminas/laminas-eventmanager": {
-        "version": "3.3.1"
-    },
-    "laminas/laminas-zendframework-bridge": {
-        "version": "1.2.0"
+        "version": "4.5.0"
     },
     "lcobucci/clock": {
-        "version": "2.0.0"
+        "version": "2.1.0"
     },
     "lcobucci/jwt": {
-        "version": "4.1.4"
+        "version": "4.1.5"
     },
     "monolog/monolog": {
-        "version": "1.26.0"
+        "version": "2.3.5"
     },
     "nikic/php-parser": {
-        "version": "v4.10.4"
+        "version": "v4.13.2"
     },
     "phpdocumentor/reflection-common": {
         "version": "2.2.0"
     },
     "phpdocumentor/reflection-docblock": {
-        "version": "5.2.2"
+        "version": "5.3.0"
     },
     "phpdocumentor/type-resolver": {
-        "version": "1.4.0"
+        "version": "1.5.1"
     },
     "psr/cache": {
-        "version": "1.0.1"
+        "version": "3.0.0"
     },
     "psr/container": {
-        "version": "1.1.1"
+        "version": "1.1.2"
+    },
+    "psr/event-dispatcher": {
+        "version": "1.0.0"
     },
     "psr/link": {
         "version": "1.1.1"
     },
     "psr/log": {
-        "version": "1.1.3"
+        "version": "2.0.0"
     },
     "sensio/framework-extra-bundle": {
-        "version": "5.2",
+        "version": "5.6",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
@@ -144,95 +138,88 @@
         ]
     },
     "symfony/amqp-messenger": {
-        "version": "v5.3.7"
+        "version": "v6.0.0"
     },
     "symfony/asset": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
     },
     "symfony/browser-kit": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
     },
     "symfony/cache": {
-        "version": "v4.4.21"
+        "version": "v6.0.0"
     },
     "symfony/cache-contracts": {
-        "version": "v2.2.0"
+        "version": "v3.0.0"
     },
     "symfony/config": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
     },
     "symfony/console": {
-        "version": "4.4",
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "4.4",
-            "ref": "ea8c0eda34fda57e7d5cd8cbd889e2a387e3472c"
+            "version": "5.3",
+            "ref": "da0c8be8157600ad34f10ff0c9cc91232522e047"
         },
         "files": [
-            "bin/console",
-            "config/bootstrap.php"
+            "bin/console"
         ]
     },
     "symfony/css-selector": {
-        "version": "v4.4.20"
-    },
-    "symfony/debug": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
     },
     "symfony/debug-bundle": {
-        "version": "4.1",
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "4.1",
-            "ref": "f8863cbad2f2e58c4b65fa1eac892ab189971bea"
+            "ref": "0ce7a032d344fb7b661cd25d31914cd703ad445b"
         },
         "files": [
             "config/packages/dev/debug.yaml"
         ]
     },
-    "symfony/debug-pack": {
-        "version": "v1.0.9"
-    },
     "symfony/dependency-injection": {
-        "version": "v4.4.21"
+        "version": "v5.4.0"
     },
     "symfony/deprecation-contracts": {
-        "version": "v2.2.0"
+        "version": "v3.0.0"
     },
     "symfony/doctrine-bridge": {
-        "version": "v4.4.21"
+        "version": "v6.0.0"
     },
     "symfony/doctrine-messenger": {
-        "version": "v5.3.10"
+        "version": "v6.0.0"
     },
     "symfony/dom-crawler": {
-        "version": "v4.4.20"
+        "version": "v6.0.0"
     },
     "symfony/dotenv": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
     },
     "symfony/error-handler": {
-        "version": "v4.4.21"
+        "version": "v6.0.0"
     },
     "symfony/event-dispatcher": {
-        "version": "v4.4.20"
+        "version": "v6.0.0"
     },
     "symfony/event-dispatcher-contracts": {
-        "version": "v1.1.9"
+        "version": "v3.0.0"
     },
     "symfony/expression-language": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
     },
     "symfony/filesystem": {
-        "version": "v4.4.21"
+        "version": "v6.0.0"
     },
     "symfony/finder": {
-        "version": "v4.4.20"
+        "version": "v6.0.0"
     },
     "symfony/flex": {
-        "version": "1.0",
+        "version": "1.17",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
@@ -244,23 +231,21 @@
         ]
     },
     "symfony/form": {
-        "version": "v4.4.21"
+        "version": "v5.4.0"
     },
     "symfony/framework-bundle": {
-        "version": "4.4",
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "4.4",
-            "ref": "df1f2fe60b8fbb5cf7e26a7af19445c128a13b90"
+            "version": "5.4",
+            "ref": "d4131812e20853626928e73d3effef44014944c0"
         },
         "files": [
-            "config/bootstrap.php",
             "config/packages/cache.yaml",
             "config/packages/framework.yaml",
-            "config/packages/test/framework.yaml",
             "config/preload.php",
-            "config/routes/dev/framework.yaml",
+            "config/routes/framework.yaml",
             "config/services.yaml",
             "public/index.php",
             "src/Controller/.gitignore",
@@ -268,37 +253,46 @@
         ]
     },
     "symfony/http-client": {
-        "version": "v4.4.21"
+        "version": "v5.4.0"
     },
     "symfony/http-client-contracts": {
-        "version": "v2.3.1"
+        "version": "v2.5.0"
     },
     "symfony/http-foundation": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
     },
     "symfony/http-kernel": {
-        "version": "v4.4.21"
-    },
-    "symfony/inflector": {
-        "version": "v4.4.21"
+        "version": "v5.4.0"
     },
     "symfony/intl": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
+    },
+    "symfony/lock": {
+        "version": "6.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "5.2",
+            "ref": "a1c8800e40ae735206bb14586fdd6c4630a51b8d"
+        },
+        "files": [
+            "config/packages/lock.yaml"
+        ]
     },
     "symfony/mailer": {
-        "version": "4.3",
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "4.3",
-            "ref": "15658c2a0176cda2e7dba66276a2030b52bd81b2"
+            "ref": "bbfc7e27257d3a3f12a6fb0a42540a42d9623a37"
         },
         "files": [
             "config/packages/mailer.yaml"
         ]
     },
     "symfony/maker-bundle": {
-        "version": "1.0",
+        "version": "1.36",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
@@ -307,7 +301,7 @@
         }
     },
     "symfony/mercure": {
-        "version": "v0.5.3"
+        "version": "v0.6.0"
     },
     "symfony/mercure-bundle": {
         "version": "0.3",
@@ -315,29 +309,29 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "0.3",
-            "ref": "d1cdff3ae53bf6a5cbfb088c82f26032bdc14cc3"
+            "ref": "e0a854b5439186e04b28fb8887b42c54f24a0d32"
         },
         "files": [
             "config/packages/mercure.yaml"
         ]
     },
     "symfony/messenger": {
-        "version": "4.3",
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "4.3",
-            "ref": "e9a414b113ceadbf4e52abe37bf8f1b443f06ccb"
+            "ref": "25e3c964d3aee480b3acc3114ffb7940c89edfed"
         },
         "files": [
             "config/packages/messenger.yaml"
         ]
     },
     "symfony/mime": {
-        "version": "v4.4.21"
+        "version": "v6.0.0"
     },
     "symfony/monolog-bridge": {
-        "version": "v4.4.21"
+        "version": "v6.0.0"
     },
     "symfony/monolog-bundle": {
         "version": "3.7",
@@ -345,7 +339,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "3.7",
-            "ref": "329f6a5ef2e7aa033f802be833ef8d1268dd0848"
+            "ref": "a7bace7dbc5a7ed5608dbe2165e0774c87175fe6"
         },
         "files": [
             "config/packages/dev/monolog.yaml",
@@ -354,19 +348,31 @@
             "config/packages/test/monolog.yaml"
         ]
     },
-    "symfony/options-resolver": {
-        "version": "v4.4.20"
-    },
-    "symfony/orm-pack": {
-        "version": "v2.1.0"
-    },
-    "symfony/phpunit-bridge": {
-        "version": "5.1",
+    "symfony/notifier": {
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "5.1",
-            "ref": "bf16921ef8309a81d9f046e9b6369c46bcbd031f"
+            "version": "5.0",
+            "ref": "c31585e252b32fe0e1f30b1f256af553f4a06eb9"
+        },
+        "files": [
+            "config/packages/notifier.yaml"
+        ]
+    },
+    "symfony/options-resolver": {
+        "version": "v6.0.0"
+    },
+    "symfony/password-hasher": {
+        "version": "v6.0.0"
+    },
+    "symfony/phpunit-bridge": {
+        "version": "5.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "5.3",
+            "ref": "97cb3dc7b0f39c7cfc4b7553504c9d7b7795de96"
         },
         "files": [
             ".env.test",
@@ -379,110 +385,106 @@
         "version": "v1.23.1"
     },
     "symfony/polyfill-intl-icu": {
-        "version": "v1.22.1"
+        "version": "v1.23.0"
     },
     "symfony/polyfill-intl-idn": {
-        "version": "v1.22.1"
+        "version": "v1.23.0"
     },
     "symfony/polyfill-intl-normalizer": {
-        "version": "v1.22.1"
+        "version": "v1.23.0"
     },
     "symfony/polyfill-mbstring": {
-        "version": "v1.22.1"
+        "version": "v1.23.1"
     },
     "symfony/polyfill-php72": {
-        "version": "v1.22.1"
+        "version": "v1.23.0"
     },
     "symfony/polyfill-php73": {
-        "version": "v1.22.1"
+        "version": "v1.23.0"
     },
     "symfony/polyfill-php80": {
-        "version": "v1.22.1"
+        "version": "v1.23.1"
     },
     "symfony/polyfill-php81": {
         "version": "v1.23.0"
     },
-    "symfony/process": {
-        "version": "v4.4.20"
+    "symfony/polyfill-uuid": {
+        "version": "v1.23.0"
     },
-    "symfony/profiler-pack": {
-        "version": "v1.0.5"
+    "symfony/process": {
+        "version": "v5.4.0"
     },
     "symfony/property-access": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
     },
     "symfony/property-info": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
     },
     "symfony/proxy-manager-bridge": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
+    },
+    "symfony/rate-limiter": {
+        "version": "v5.4.0"
     },
     "symfony/redis-messenger": {
-        "version": "v5.3.10"
+        "version": "v6.0.0"
     },
     "symfony/routing": {
-        "version": "4.2",
+        "version": "6.0",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "4.2",
-            "ref": "683dcb08707ba8d41b7e34adb0344bfd68d248a7"
+            "version": "6.0",
+            "ref": "ab9ad892b7bba7ac584f6dc2ccdb659d358c63c5"
         },
         "files": [
-            "config/packages/prod/routing.yaml",
             "config/packages/routing.yaml",
             "config/routes.yaml"
         ]
     },
     "symfony/security-bundle": {
-        "version": "4.4",
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "4.4",
-            "ref": "7b4408dc203049666fe23fabed23cbadc6d8440f"
+            "version": "5.3",
+            "ref": "3307d76caa2d12fb10ade57975beb3d8975df396"
         },
         "files": [
             "config/packages/security.yaml"
         ]
     },
     "symfony/security-core": {
-        "version": "v4.4.21"
+        "version": "v6.0.0"
     },
     "symfony/security-csrf": {
-        "version": "v4.4.20"
+        "version": "v6.0.0"
     },
     "symfony/security-guard": {
-        "version": "v4.4.20"
+        "version": "v5.4.0-BETA1"
     },
     "symfony/security-http": {
-        "version": "v4.4.21"
+        "version": "v6.0.0"
     },
     "symfony/serializer": {
-        "version": "v4.4.20"
-    },
-    "symfony/serializer-pack": {
-        "version": "v1.0.4"
+        "version": "v5.4.0"
     },
     "symfony/service-contracts": {
-        "version": "v2.2.0"
+        "version": "v2.4.1"
     },
     "symfony/stopwatch": {
-        "version": "v4.4.20"
+        "version": "v5.4.0"
     },
     "symfony/string": {
         "version": "v6.0.0"
     },
-    "symfony/test-pack": {
-        "version": "v1.0.7"
-    },
     "symfony/translation": {
-        "version": "3.3",
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "3.3",
-            "ref": "2ad9d2545bce8ca1a863e50e92141f0b9d87ffcd"
+            "version": "5.3",
+            "ref": "da64f5a2b6d96f5dc24914517c0350a5f91dee43"
         },
         "files": [
             "config/packages/translation.yaml",
@@ -490,35 +492,34 @@
         ]
     },
     "symfony/translation-contracts": {
-        "version": "v2.3.0"
+        "version": "v2.5.0"
     },
     "symfony/twig-bridge": {
-        "version": "v4.4.21"
+        "version": "v6.0.0"
     },
     "symfony/twig-bundle": {
-        "version": "4.4",
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "4.4",
-            "ref": "15a41bbd66a1323d09824a189b485c126bbefa51"
+            "version": "5.4",
+            "ref": "bffbb8f1a849736e64006735afae730cb428b6ff"
         },
         "files": [
-            "config/packages/test/twig.yaml",
             "config/packages/twig.yaml",
             "templates/base.html.twig"
         ]
     },
-    "symfony/twig-pack": {
-        "version": "v1.0.1"
+    "symfony/uid": {
+        "version": "v5.4.0"
     },
     "symfony/validator": {
-        "version": "4.3",
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "4.3",
-            "ref": "d902da3e4952f18d3bf05aab29512eb61cabd869"
+            "ref": "3eb8df139ec05414489d55b97603c5f6ca0c44cb"
         },
         "files": [
             "config/packages/test/validator.yaml",
@@ -526,16 +527,16 @@
         ]
     },
     "symfony/var-dumper": {
-        "version": "v4.4.21"
+        "version": "v5.4.0"
     },
     "symfony/var-exporter": {
-        "version": "v4.4.20"
+        "version": "v6.0.0"
     },
     "symfony/web-link": {
-        "version": "v4.4.21"
+        "version": "v5.4.0"
     },
     "symfony/web-profiler-bundle": {
-        "version": "3.3",
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
@@ -549,12 +550,12 @@
         ]
     },
     "symfony/webpack-encore-bundle": {
-        "version": "1.9",
+        "version": "1.13",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "1.9",
-            "ref": "9399a0bfc6ee7a0c019f952bca46d6a6045dd451"
+            "ref": "0f274572ea315eb3b5884518a50ca43f211b4534"
         },
         "files": [
             "assets/app.js",
@@ -571,13 +572,13 @@
         ]
     },
     "symfony/yaml": {
-        "version": "v4.4.21"
+        "version": "v5.4.0"
     },
     "twig/extra-bundle": {
-        "version": "v3.3.0"
+        "version": "v3.3.4"
     },
     "twig/twig": {
-        "version": "v3.3.0"
+        "version": "v3.3.4"
     },
     "webmozart/assert": {
         "version": "1.10.0"


### PR DESCRIPTION
The "extra" section does not have much effect anymore.

```
    "extra": {
        "symfony": {
            "allow-contrib": false,
            "require": "5.4.*"
        }
    },
```

Before this PR we were installing "symfony/routing": "6.0". 

FYI @nicolas-grekas 