### PR TITLE
[4.4] Allow the symfony/flex plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
It should fix the test of https://github.com/symfony/symfony-docs/pull/16883:

```bash
git clone -b 4.4 --depth 5 --single-branch https://github.com/symfony-tools/symfony-application.git _sf_app
# …
Error: symfony/flex contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
You can run "composer config --no-plugins allow-plugins.symfony/flex [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
```
[full log](https://github.com/symfony/symfony-docs/runs/7217315010?check_suite_focus=true)

---

I took the conf from #11