### PR TITLE
merge 4.4 to 5.4 (allow composer to run the symfony/flex plugin)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
         "symfony/web-profiler-bundle": "^4.4"
     },
     "config": {
+        "allow-plugins": {
+            "symfony/flex": true
+        },
         "preferred-install": {
             "*": "dist"
         },

--- a/composer.json
+++ b/composer.json
@@ -56,10 +56,7 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true,
-        "allow-plugins": {
-            "symfony/flex": true
-        }
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
follow-up of #12

It should fix CI issues like in https://github.com/symfony/symfony-docs/runs/7303736198?check_suite_focus=true

The logs will be erased in the future, here are the logs for further reference:

```
git clone -b 5.4 --depth 5 --single-branch https://github.com/symfony-tools/symfony-application.git _sf_app
  cd _sf_app
  composer update
[…]

Error: symfony/flex contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
You can run "composer config --no-plugins allow-plugins.symfony/flex [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
```