### PR TITLE
Proposing adding asset-mapper to 6.3 app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "phpdocumentor/reflection-docblock": "^5.2",
         "sensio/framework-extra-bundle": "^6.1",
         "symfony/asset": "6.3.*",
+        "symfony/asset-mapper": "6.3.*",
         "symfony/console": "6.3.*",
         "symfony/dotenv": "6.3.*",
         "symfony/expression-language": "6.3.*",


### PR DESCRIPTION
It's a bit non-realistic to have AssetMapper & WebpackEncoreBundle installed in the same app... not sure if that would cause problems, but let's see.