### PR TITLE
Add the scheduler component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "symfony/proxy-manager-bridge": "6.3.*",
         "symfony/rate-limiter": "6.3.*",
         "symfony/routing": "6.3.*",
+        "symfony/scheduler": "6.3.*",
         "symfony/security-bundle": "6.3.*",
         "symfony/serializer": "6.3.*",
         "symfony/translation": "6.3.*",


### PR DESCRIPTION
https://github.com/symfony/symfony-docs/actions/runs/7575621828/job/20632633360?pr=19440

```
Run ../_checker/code-block-checker.php verify:docs `pwd` scheduler.rst  --baseline=baseline.json --output-format=github --symfony-application=`realpath ../_sf_app`

Error: [Missing class] Class, interface or trait with name "Symfony\Component\Scheduler\Attribute\AsSchedule" does not exist
Error: [Missing class] Class, interface or trait with name "Symfony\Component\Scheduler\Schedule" does not exist
Error: [Missing class] Class, interface or trait with name "Symfony\Component\Scheduler\ScheduleProviderInterface" does not exist
Error: Process completed with exit code 1.
```