### PR TITLE
Remove legacy twig.exception_controller option

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -2,4 +2,3 @@ twig:
     default_path: '%kernel.project_dir%/templates'
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
-    exception_controller: null


### PR DESCRIPTION
Related to https://github.com/symfony/symfony-docs/pull/21410 /cc @javiereguiluz 