### PR TITLE
Add symfony/ldap dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "symfony/intl": "*",
         "symfony/json-path": "*",
         "symfony/json-streamer": "*",
+        "symfony/ldap": "*",
         "symfony/lock": "*",
         "symfony/mailer": "*",
         "symfony/mercure-bundle": "^0.3.2",


### PR DESCRIPTION
Required to validate LDAP-related code blocks from the Symfony documentation (e.g. Symfony\Component\Ldap\Security\MemberOfRoles introduced in 7.3, used in symfony/symfony-docs#22237).