### PR TITLE
bump Symfony Flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/dotenv": "*",
         "symfony/emoji": "7.1.*",
         "symfony/expression-language": "*",
-        "symfony/flex": "^1.3.1",
+        "symfony/flex": "^2.10",
         "symfony/form": "*",
         "symfony/framework-bundle": "*",
         "symfony/html-sanitizer": "*",


### PR DESCRIPTION
Since Symfony 7.4 the HttpKernel component conflicts with Flex < 2.10 (see symfony/symfony#62411).