### PR TITLE
Bump extra.symfony.require to 8.2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "8.1.*"
+            "require": "8.2.*"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
The `8.2` branch still pins `extra.symfony.require` to `8.1.*`, so the application resolves the released `8.1.x` packages instead of `8.2.x-dev`.

As this application is what the symfony-docs `Code Blocks` check runs `class_exists()` against, every docs PR that documents a new 8.2 class currently fails that check with `[Missing class]`. Concrete example: symfony/symfony-docs#22790, which documents the new `#[AutowireClassMap]` attribute merged in symfony/symfony#65370.

With `minimum-stability: dev` + `prefer-stable` already in place, bumping the pin makes composer resolve the symfony packages to `8.2.x-dev`, so the classes of the branch under documentation actually exist.
