### PR TITLE
Pin the 8.2 branch to Symfony 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "8.1.*"
+            "require": "8.2.*"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
The `8.2` branch was created from `8.1` but `extra.symfony.require` was never bumped, so the
test application still installs Symfony 8.1. Every other branch pins its own version
(`7.4` → `7.4.*`, `8.0` → `8.0.*`, `8.1` → `8.1.*`).

As a result, the "Code Blocks" job of symfony-docs PRs targeting `8.2` fails on any YAML
example using an option introduced in 8.2. For instance
https://github.com/symfony/symfony-docs/pull/22776 fails with:

```
Unrecognized option "signature_format" under "framework.webhook". Available options are
"enabled", "event_header_name", "id_header_name", "message_bus", "routing",
"signature_header_name", "signing_algorithm".
```
